### PR TITLE
fix: list only onboarded participants

### DIFF
--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/AuthorityExtension.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/AuthorityExtension.java
@@ -24,12 +24,12 @@ import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry
 import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClientImpl;
 import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtServiceImpl;
 import org.eclipse.dataspaceconnector.registration.api.RegistrationApiController;
-import org.eclipse.dataspaceconnector.registration.api.RegistrationService;
 import org.eclipse.dataspaceconnector.registration.auth.DidJwtAuthenticationFilter;
 import org.eclipse.dataspaceconnector.registration.authority.spi.ParticipantVerifier;
 import org.eclipse.dataspaceconnector.registration.credential.VerifiableCredentialService;
 import org.eclipse.dataspaceconnector.registration.credential.VerifiableCredentialServiceImpl;
 import org.eclipse.dataspaceconnector.registration.manager.ParticipantManager;
+import org.eclipse.dataspaceconnector.registration.service.RegistrationService;
 import org.eclipse.dataspaceconnector.registration.store.InMemoryParticipantStore;
 import org.eclipse.dataspaceconnector.registration.store.spi.ParticipantStore;
 import org.eclipse.dataspaceconnector.registration.transform.ParticipantToParticipantDtoTransformer;

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import org.eclipse.dataspaceconnector.registration.model.ParticipantDto;
+import org.eclipse.dataspaceconnector.registration.service.RegistrationService;
 
 import java.util.List;
 import java.util.Objects;
@@ -83,7 +84,7 @@ public class RegistrationApiController {
 
     @Path("/participants")
     @GET
-    @Operation(description = "Gets all dataspace participants.")
+    @Operation(description = "Gets all participants onboarded in the dataspace.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
@@ -97,7 +98,7 @@ public class RegistrationApiController {
             )
     })
     public List<ParticipantDto> listParticipants() {
-        return service.listParticipants();
+        return service.listOnboardedParticipants();
     }
 
     @Path("/participant")

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
@@ -101,7 +101,6 @@ public class RegistrationApiController {
         return service.listOnboardedParticipants();
     }
 
-    
     @Path("/participant")
     @Operation(description = "Asynchronously request to add a dataspace participant.")
     @ApiResponse(responseCode = "204", description = "No content")

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
@@ -101,6 +101,7 @@ public class RegistrationApiController {
         return service.listOnboardedParticipants();
     }
 
+    
     @Path("/participant")
     @Operation(description = "Asynchronously request to add a dataspace participant.")
     @ApiResponse(responseCode = "204", description = "No content")

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/manager/ParticipantManager.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/manager/ParticipantManager.java
@@ -92,6 +92,7 @@ public class ParticipantManager {
         var credentialsValid = participantVerifier.isOnboardingAllowed(participant.getDid());
         if (credentialsValid.failed()) {
             monitor.info("Process 21 : " + participant.getDid());
+            monitor.info("Process 21b : " + credentialsValid.getFailureDetail());
             participant.transitionFailed();
         } else if (credentialsValid.getContent()) {
             monitor.info("Process 22 : " + participant.getDid());

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/service/RegistrationService.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/service/RegistrationService.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.registration.api;
+package org.eclipse.dataspaceconnector.registration.service;
 
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.registration.authority.model.Participant;
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus.ONBOARDED;
 import static org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus.ONBOARDING_INITIATED;
 
 /**
@@ -68,14 +69,16 @@ public class RegistrationService {
     }
 
     /**
-     * Lists all dataspace participants.
+     * Lists all dataspace participants in state {@ref #ONBOARDED}.
      *
      * @return list of dataspace participants as DTOs.
      */
-    public List<ParticipantDto> listParticipants() {
-        monitor.info("List all participants of the dataspace.");
+    public List<ParticipantDto> listOnboardedParticipants() {
+        monitor.info("List onboarded participants of the dataspace.");
 
-        return participantStore.listParticipants().stream()
+        return participantStore
+                .listParticipantsWithStatus(ONBOARDED)
+                .stream()
                 .map(participant -> transformerRegistry.transform(participant, ParticipantDto.class))
                 .filter(Result::succeeded)
                 .map(Result::getContent)

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/service/RegistrationService.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/service/RegistrationService.java
@@ -91,7 +91,7 @@ public class RegistrationService {
      * @param did the DID of the dataspace participant to add.
      */
     public void addParticipant(String did) {
-        monitor.info("Adding a participant in the dataspace.");
+        monitor.info("Adding a participant in the dataspace: " + did);
 
         var participant = Participant.Builder.newInstance()
                 .did(did)

--- a/resources/openapi/yaml/registration-service.yaml
+++ b/resources/openapi/yaml/registration-service.yaml
@@ -28,7 +28,7 @@ paths:
       - Registry
   /registry/participants:
     get:
-      description: Gets all dataspace participants.
+      description: Gets all participants onboarded in the dataspace.
       operationId: listParticipants
       responses:
         "200":

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
@@ -18,7 +18,6 @@ import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpStatusCode;
 
@@ -70,7 +69,7 @@ class RegistrationApiClientTest {
         stopQuietly(httpSourceClientAndServer);
     }
 
-    @Test
+    //@Test
     void listParticipants() throws Exception {
         assertThat(api.listParticipants())
                 .noneSatisfy(p -> assertThat(p.getDid()).isEqualTo(did));
@@ -81,7 +80,7 @@ class RegistrationApiClientTest {
                 () -> assertThat(api.listParticipants()).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did)));
     }
 
-    @Test
+    //@Test
     void addsVerifiableCredential() throws Exception {
         // jwt claims issue time is set with 1 sec precision, so startTime is set to 1 second before
         var startTime = Instant.now().truncatedTo(SECONDS).minus(1, SECONDS);
@@ -103,7 +102,7 @@ class RegistrationApiClientTest {
         return result.getContent();
     }
 
-    @Test
+    //@Test
     void getParticipant() {
         api.addParticipant();
 
@@ -112,7 +111,7 @@ class RegistrationApiClientTest {
         assertThat(response.getDid()).isEqualTo(did);
     }
 
-    @Test
+    //@Test
     void getParticipant_notFound() {
 
         // look for participant which is not yet registered.

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
@@ -79,9 +79,8 @@ class RegistrationApiClientTest {
 
         Thread.sleep(20000);
 
-        assertThat(api.listParticipants())
-                .anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did));
-
+        await().atMost(2, MINUTES).untilAsserted(
+                () -> assertThat(api.listParticipants()).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did)));
     }
 
     @Test

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
-import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.HUB_BASE_URL;
+import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.HUB_BASE_URL_LOCAL;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.addEnrollmentCredential;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.createApi;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.createDid;
@@ -77,8 +77,6 @@ class RegistrationApiClientTest {
 
         addsVerifiableCredential();
 
-        Thread.sleep(20000);
-
         await().atMost(2, MINUTES).untilAsserted(
                 () -> assertThat(api.listParticipants()).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did)));
     }
@@ -100,7 +98,7 @@ class RegistrationApiClientTest {
     }
 
     private Collection<SignedJWT> getVerifiableCredentialsFromIdentityHub() {
-        var result = identityHubClient.getVerifiableCredentials(HUB_BASE_URL);
+        var result = identityHubClient.getVerifiableCredentials(HUB_BASE_URL_LOCAL);
         assertThat(result.succeeded()).isTrue();
         return result.getContent();
     }

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
@@ -18,6 +18,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpStatusCode;
 
@@ -69,7 +70,7 @@ class RegistrationApiClientTest {
         stopQuietly(httpSourceClientAndServer);
     }
 
-    //@Test
+    @Test
     void listParticipants() throws Exception {
         assertThat(api.listParticipants())
                 .noneSatisfy(p -> assertThat(p.getDid()).isEqualTo(did));
@@ -80,7 +81,7 @@ class RegistrationApiClientTest {
                 () -> assertThat(api.listParticipants()).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did)));
     }
 
-    //@Test
+    @Test
     void addsVerifiableCredential() throws Exception {
         // jwt claims issue time is set with 1 sec precision, so startTime is set to 1 second before
         var startTime = Instant.now().truncatedTo(SECONDS).minus(1, SECONDS);
@@ -102,7 +103,7 @@ class RegistrationApiClientTest {
         return result.getContent();
     }
 
-    //@Test
+    @Test
     void getParticipant() {
         api.addParticipant();
 
@@ -111,7 +112,7 @@ class RegistrationApiClientTest {
         assertThat(response.getDid()).isEqualTo(did);
     }
 
-    //@Test
+    @Test
     void getParticipant_notFound() {
 
         // look for participant which is not yet registered.

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
@@ -88,13 +88,6 @@ class RegistrationApiClientTest {
     void addsVerifiableCredential() throws Exception {
         // jwt claims issue time is set with 1 sec precision, so startTime is set to 1 second before
         var startTime = Instant.now().truncatedTo(SECONDS).minus(1, SECONDS);
-        var key = Files.readString(new File(TestUtils.findBuildRoot(), "resources/vault/private-key.pem").toPath());
-        var authorityPrivateKey = CryptoUtils.parseFromPemEncodedObjects(key);
-        var jwtService = new VerifiableCredentialsJwtServiceImpl(new ObjectMapper(), MONITOR);
-        var vc = VerifiableCredential.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .credentialSubject(Map.of("gaiaXMember", "true"))
-                .build();
 
         // sanity check
         assertThat(getVerifiableCredentialsFromIdentityHub()).noneSatisfy(token -> assertIssuedVerifiableCredential(token, did, startTime));

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -88,7 +88,7 @@ class RegistrationApiCommandLineClientTest {
                 () -> assertThat(listParticipantCmd(did)).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did)));
     }
 
-    @Test
+    //@Test
     void getParticipant() throws Exception {
 
         addParticipantCmd(did);
@@ -99,7 +99,7 @@ class RegistrationApiCommandLineClientTest {
         assertThat(result.getStatus()).isNotNull();
     }
 
-    @Test
+    //@Test
     void getParticipant_notFound() {
         CommandLine cmd = RegistrationServiceCli.getCommandLine();
         var writer = new StringWriter();

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -37,7 +37,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
-import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.DATASPACE_DID_WEB2;
+import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.DATASPACE_DID_WEB_LOCAL;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.addEnrollmentCredential;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.createDid;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.didDocument;
@@ -107,7 +107,7 @@ class RegistrationApiCommandLineClientTest {
 
         var statusCmdExitCode = cmd.execute(
                 "-c", did,
-                "-d", DATASPACE_DID_WEB2,
+                "-d", DATASPACE_DID_WEB_LOCAL,
                 "-k", privateKeyFile.toString(),
                 "--http-scheme",
                 "participants", "get");
@@ -134,7 +134,7 @@ class RegistrationApiCommandLineClientTest {
 
         return List.of(
                 "-c", didWeb,
-                "-d", DATASPACE_DID_WEB2,
+                "-d", DATASPACE_DID_WEB_LOCAL,
                 "-k", privateKeyFile.toString(),
                 "--http-scheme",
                 "participants"

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -37,13 +37,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationApiClientTest.HUB_BASE_URL;

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -33,7 +33,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.DATASPACE_DID_WEB2;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.addEnrollmentCredential;
@@ -82,9 +84,8 @@ class RegistrationApiCommandLineClientTest {
 
         addParticipantCmd(did);
 
-        Thread.sleep(20000);
-
-        assertThat(listParticipantCmd(did)).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did));
+        await().atMost(2, MINUTES).untilAsserted(
+                () -> assertThat(listParticipantCmd(did)).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did)));
     }
 
     @Test

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -88,7 +88,7 @@ class RegistrationApiCommandLineClientTest {
                 () -> assertThat(listParticipantCmd(did)).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did)));
     }
 
-    //@Test
+    @Test
     void getParticipant() throws Exception {
 
         addParticipantCmd(did);
@@ -99,7 +99,7 @@ class RegistrationApiCommandLineClientTest {
         assertThat(result.getStatus()).isNotNull();
     }
 
-    //@Test
+    @Test
     void getParticipant_notFound() {
         CommandLine cmd = RegistrationServiceCli.getCommandLine();
         var writer = new StringWriter();

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -62,12 +62,12 @@ public class RegistrationApiCommandLineClientTest {
         privateKeyFile.toFile().deleteOnExit();
         Files.writeString(privateKeyFile, TestKeyData.PRIVATE_KEY_P256);
         apiPort = getFreePort();
+        did = createDid(apiPort);
         httpSourceClientAndServer = startClientAndServer(apiPort);
         httpSourceClientAndServer.when(request().withPath("/.well-known/did.json"))
                 .respond(response()
-                        .withBody(didDocument())
+                        .withBody(didDocument(did))
                         .withStatusCode(HttpStatusCode.OK_200.code()));
-        did = createDid(apiPort);
     }
 
     @AfterEach

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -17,12 +17,6 @@ package org.eclipse.dataspaceconnector.registration.client;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import okhttp3.OkHttpClient;
-import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClientImpl;
-import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtServiceImpl;
-import org.eclipse.dataspaceconnector.identityhub.credentials.model.VerifiableCredential;
-import org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils;
-import org.eclipse.dataspaceconnector.registration.cli.CryptoUtils;
 import org.eclipse.dataspaceconnector.registration.cli.RegistrationServiceCli;
 import org.eclipse.dataspaceconnector.registration.client.models.ParticipantDto;
 import org.junit.jupiter.api.AfterEach;
@@ -32,22 +26,17 @@ import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpStatusCode;
 import picocli.CommandLine;
 
-import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
-import static org.eclipse.dataspaceconnector.registration.client.RegistrationApiClientTest.HUB_BASE_URL;
-import static org.eclipse.dataspaceconnector.registration.client.RegistrationApiClientTest.MONITOR;
-import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.DATASPACE_DID_WEB;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.DATASPACE_DID_WEB2;
+import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.addEnrollmentCredential;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.createDid;
 import static org.eclipse.dataspaceconnector.registration.client.RegistrationServiceTestUtils.didDocument;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
@@ -56,18 +45,14 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.stop.Stop.stopQuietly;
 
 @IntegrationTest
-public class RegistrationApiCommandLineClientTest {
+class RegistrationApiCommandLineClientTest {
 
     static final ObjectMapper MAPPER = new ObjectMapper();
     static Path privateKeyFile;
 
     int apiPort;
     String did;
-    /*
-    host.docker.internal is used in docker-compose file to connect from Registration Service container to a mock-service on the host
-     */
     ClientAndServer httpSourceClientAndServer;
-    private IdentityHubClientImpl identityHubClient;
 
     @BeforeEach
     void setUpClass() throws Exception {
@@ -81,8 +66,6 @@ public class RegistrationApiCommandLineClientTest {
                 .respond(response()
                         .withBody(didDocument(did))
                         .withStatusCode(HttpStatusCode.OK_200.code()));
-        var okHttpClient = new OkHttpClient.Builder().build();
-        identityHubClient = new IdentityHubClientImpl(okHttpClient, new ObjectMapper(), MONITOR);
     }
 
     @AfterEach
@@ -95,20 +78,11 @@ public class RegistrationApiCommandLineClientTest {
 
         assertThat(listParticipantCmd(did)).noneSatisfy(p -> assertThat(p.getDid()).isEqualTo(did));
 
-        var key = Files.readString(new File(TestUtils.findBuildRoot(), "resources/vault/private-key.pem").toPath());
-        var authorityPrivateKey = CryptoUtils.parseFromPemEncodedObjects(key);
-        var jwtService = new VerifiableCredentialsJwtServiceImpl(new ObjectMapper(), MONITOR);
-        var vc = VerifiableCredential.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .credentialSubject(Map.of("gaiaXMember", "true"))
-                .build();
-
-        var jwt = jwtService.buildSignedJwt(vc, DATASPACE_DID_WEB, did, authorityPrivateKey);
-        identityHubClient.addVerifiableCredential(HUB_BASE_URL, jwt);
+        addEnrollmentCredential(did);
 
         addParticipantCmd(did);
 
-        Thread.sleep(10000);
+        Thread.sleep(20000);
 
         assertThat(listParticipantCmd(did)).anySatisfy(p -> assertThat(p.getDid()).isEqualTo(did));
     }

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationServiceTestUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationServiceTestUtils.java
@@ -37,14 +37,14 @@ class RegistrationServiceTestUtils {
      * The DID that resolves to the sample DID Document for the Dataspace Authority in docker compose (served by the nginx container).
      * Did web format reference: https://w3c-ccg.github.io/did-method-web/#create-register
      */
-    static final String DATASPACE_DID_WEB = "did:web:localhost%3A8080:test-dataspace-authority";
+    static final String DATASPACE_DID_WEB = createDid(8080) + ":test-dataspace-authority";
 
     /**
      * Url of IdentityHub of the participant from docker compose (served by the nginx container).
      */
     static final String IDENTITY_HUB_URL = "http://participant:8181/api/identity-hub";
 
-    static String didDocument() throws Exception {
+    static String didDocument(String did) throws Exception {
         var publicKey = (ECKey) ECKey.parseFromPEMEncodedObjects(TestKeyData.PUBLIC_KEY_P256);
         var vm = VerificationMethod.Builder.create()
                 .id("#my-key-1")
@@ -53,6 +53,7 @@ class RegistrationServiceTestUtils {
                 .publicKeyJwk(new EllipticCurvePublicKey(publicKey.getCurve().getName(), publicKey.getKeyType().getValue(), publicKey.getX().toString(), publicKey.getY().toString()))
                 .build();
         var didDocument = DidDocument.Builder.newInstance()
+                .id(did)
                 .verificationMethod(List.of(vm))
                 .service(List.of(identityHub()))
                 .build();

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationServiceTestUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationServiceTestUtils.java
@@ -38,6 +38,8 @@ class RegistrationServiceTestUtils {
      * Did web format reference: https://w3c-ccg.github.io/did-method-web/#create-register
      */
     static final String DATASPACE_DID_WEB = createDid(8080) + ":test-dataspace-authority";
+    static final String DATASPACE_DID_WEB2 = "did:web:localhost%3A8080:test-dataspace-authority";
+
 
     /**
      * Url of IdentityHub of the participant from docker compose (served by the nginx container).

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationServiceTestUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationServiceTestUtils.java
@@ -44,19 +44,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RegistrationServiceTestUtils {
     static final ObjectMapper MAPPER = new ObjectMapper();
     /**
-     * The DID that resolves to the sample DID Document for the Dataspace Authority in docker compose (served by the nginx container).
-     * Did web format reference: https://w3c-ccg.github.io/did-method-web/#create-register
+     * The <a href="https://w3c-ccg.github.io/did-method-web/#create-register">Web DID</a>
+     * that resolves to the sample DID Document for the Dataspace Authority from the test runtime.
      */
-    static final String DATASPACE_DID_WEB = createDid(8080) + ":test-dataspace-authority";
-    static final String DATASPACE_DID_WEB2 = "did:web:localhost%3A8080:test-dataspace-authority";
+    static final String DATASPACE_DID_WEB_LOCAL = "did:web:localhost%3A8080:test-dataspace-authority";
+
     /**
-     * URL of IdentityHub of the participant from test runtime.
+     * The Web DID that resolves to the sample DID Document for the Dataspace Authority in docker compose (served by the nginx container).
      */
-    static final String HUB_BASE_URL = "http://localhost:8181/api/identity-hub";
+    static final String DATASPACE_DID_WEB_DOCKER = createDid(8080) + ":test-dataspace-authority";
+
+    /**
+     * URL of IdentityHub of the participant from the test runtime.
+     */
+    static final String HUB_BASE_URL_LOCAL = "http://localhost:8181/api/identity-hub";
+
     /**
      * URL of IdentityHub of the participant from docker compose (served by the nginx container).
      */
-    static final String IDENTITY_HUB_URL = "http://participant:8181/api/identity-hub";
+    static final String HUB_BASE_URL_DOCKER = "http://participant:8181/api/identity-hub";
 
     static final Monitor MONITOR = new ConsoleMonitor();
 
@@ -97,7 +103,7 @@ class RegistrationServiceTestUtils {
 
     @NotNull
     private static Service identityHub() {
-        return new Service("#identity-hub", "IdentityHub", IDENTITY_HUB_URL);
+        return new Service("#identity-hub", "IdentityHub", HUB_BASE_URL_DOCKER);
     }
 
     static void addEnrollmentCredential(String did) throws Exception {
@@ -108,8 +114,8 @@ class RegistrationServiceTestUtils {
                 .credentialSubject(Map.of("gaiaXMember", "true"))
                 .build();
 
-        var jwt = jwtService.buildSignedJwt(vc, DATASPACE_DID_WEB, did, authorityPrivateKey);
-        var addVcResult = identityHubClient.addVerifiableCredential(HUB_BASE_URL, jwt);
+        var jwt = jwtService.buildSignedJwt(vc, DATASPACE_DID_WEB_DOCKER, did, authorityPrivateKey);
+        var addVcResult = identityHubClient.addVerifiableCredential(HUB_BASE_URL_LOCAL, jwt);
         assertThat(addVcResult.succeeded()).isTrue();
     }
 }

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationServiceTestUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationServiceTestUtils.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,6 +68,7 @@ class RegistrationServiceTestUtils {
     static OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
     static IdentityHubClientImpl identityHubClient = new IdentityHubClientImpl(okHttpClient, new ObjectMapper(), MONITOR);
     static VerifiableCredentialsJwtServiceImpl jwtService = new VerifiableCredentialsJwtServiceImpl(MAPPER, MONITOR);
+    private static String enrollmentCredentialId = "5067AB66-61A4-4F8E-ADE0-7BDF376F8DB5";
 
     private RegistrationServiceTestUtils() {
     }
@@ -110,7 +110,7 @@ class RegistrationServiceTestUtils {
         var key = Files.readString(new File(TestUtils.findBuildRoot(), "resources/vault/private-key.pem").toPath());
         var authorityPrivateKey = CryptoUtils.parseFromPemEncodedObjects(key);
         var vc = VerifiableCredential.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
+                .id(enrollmentCredentialId)
                 .credentialSubject(Map.of("gaiaXMember", "true"))
                 .build();
 


### PR DESCRIPTION
## What this PR changes/adds

List participants endpoint only returns participants in ONBOARDED state, rather than all "participants" in any state

## Why it does that

Currently, the EDC crawler will fetch catalog data from participants that have a DENIED status. It should only crawl participants that are ONBOARDED.

There is no justifiable reason for "leaking" the details of participants that are not onboarded to other participants, hence this filtering is done server-side.

## Further notes

Also moved service class to its proper package

## Linked Issue(s)

https://github.com/eclipse-dataspaceconnector/RegistrationService/issues/35

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
