### PR TITLE
chore: fix compile error due to upstream changes

### DIFF
--- a/client-cli/build.gradle.kts
+++ b/client-cli/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(edc.ext.identity.did.web)
     implementation(edc.ext.identity.did.crypto)
     implementation(libs.okhttp)
+    implementation(edc.core.connector)
 
     testImplementation(testFixtures(project(":rest-client")))
 }


### PR DESCRIPTION
## What this PR changes/adds

Replaces the use of an `OkHttpClient` with the newly introduced `EdcHttpClient`.

## Why it does that

Upstream changes, broke the build.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
