### PR TITLE
feat: add override flag for RegSrv URL

### DIFF
--- a/client-cli/src/main/java/org/eclipse/edc/registration/cli/RegistrationServiceCli.java
+++ b/client-cli/src/main/java/org/eclipse/edc/registration/cli/RegistrationServiceCli.java
@@ -51,6 +51,9 @@ public class RegistrationServiceCli {
     Path privateKeyFile;
     @CommandLine.Option(names = "--http-scheme", description = "Flag to create DID URLs with http instead of https scheme. Used for testing purposes.")
     boolean useHttpScheme;
+    @CommandLine.Option(names = { "--url", "-u" }, description = "Override for the registration service URL. Normally it would be taken from the Dataspace's DID document. Used for testing purposes")
+    String registrationServiceUrlOverride;
+
     RegistryApi registryApiClient;
 
     public static void main(String... args) {
@@ -78,7 +81,12 @@ public class RegistrationServiceCli {
             throw new RuntimeException("Error reading file " + privateKeyFile, e);
         }
 
-        registryApiClient = new RegistryApi(createApiClient(registrationUrl(), clientDid, privateKeyData));
+        var apiClient = createApiClient(registrationUrl(), clientDid, privateKeyData);
+        if (registrationServiceUrlOverride != null) {
+            monitor.info("Overriding RegistrationService URL: " + registrationServiceUrlOverride);
+            apiClient.updateBaseUri(registrationServiceUrlOverride);
+        }
+        registryApiClient = new RegistryApi(apiClient);
     }
 
     private String registrationUrl() {


### PR DESCRIPTION
## What this PR changes/adds

adds the `-u <REG_SRV_URL>` flag to the CLI to override the registration service URL.

## Why it does that

This feature is useful in docker environments, where the RegistrationService is known under its Docker network hostname (`"registration-service"`) but the CLI is used from outside docker.

## Further notes

.
## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
