### PR TITLE
fix: add Monitor to EdcHttpClient's arguments

### DIFF
--- a/client-cli/src/main/java/org/eclipse/edc/registration/cli/RegistrationServiceCli.java
+++ b/client-cli/src/main/java/org/eclipse/edc/registration/cli/RegistrationServiceCli.java
@@ -60,7 +60,6 @@ public class RegistrationServiceCli {
     String registrationServiceUrlOverride;
 
     RegistryApi registryApiClient;
-    private EdcHttpClient edcHttpClient;
 
     public static void main(String... args) {
         CommandLine commandLine = getCommandLine();
@@ -115,6 +114,6 @@ public class RegistrationServiceCli {
         var retryPolicy = RetryPolicy.<Response>builder().withMaxRetries(3)
                 .withBackoff(Duration.ofSeconds(2), Duration.ofSeconds(5))
                 .build();
-        return new EdcHttpClientImpl(httpClient, retryPolicy);
+        return new EdcHttpClientImpl(httpClient, retryPolicy, new ConsoleMonitor("RegistrationService CLI", ConsoleMonitor.Level.INFO));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds the `Monitor` argument to the `EdcHttpClient`'s constructor args when creating the RegistrationService CLI

## Why it does that

compile errors

## Further notes
.

## Linked Issue(s)
.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
