### PR TITLE
chore: remove publications

### DIFF
--- a/core/registration-service-client/build.gradle.kts
+++ b/core/registration-service-client/build.gradle.kts
@@ -69,11 +69,3 @@ dependencies {
     implementation(libs.bundles.jackson)
     implementation(libs.openapi.jackson.databind.nullable)
 }
-
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}

--- a/core/registration-service-onboarding-policy-verifier/build.gradle.kts
+++ b/core/registration-service-onboarding-policy-verifier/build.gradle.kts
@@ -7,11 +7,3 @@ dependencies {
     api(edc.spi.identity.did)
     api(project(":spi:registration-service-spi"))
 }
-
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}

--- a/extensions/store/sql/participant-store-sql/build.gradle.kts
+++ b/extensions/store/sql/participant-store-sql/build.gradle.kts
@@ -13,11 +13,3 @@ dependencies {
     testImplementation(testFixtures(project(":spi:registration-service-store-spi")))
     testImplementation(testFixtures(project(":spi:registration-service-spi")))
 }
-
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -55,3 +55,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("app.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/registration-service-cli/build.gradle.kts
+++ b/registration-service-cli/build.gradle.kts
@@ -28,12 +28,3 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("registration-service-cli.jar")
 }
-
-publishing {
-    publications {
-        create<MavenPublication>("registration-service-cli") {
-            artifactId = "registration-service-cli"
-            from(components["java"])
-        }
-    }
-}

--- a/spi/registration-service-spi/build.gradle.kts
+++ b/spi/registration-service-spi/build.gradle.kts
@@ -10,11 +10,3 @@ dependencies {
     api(identityHub.spi.core)
     implementation(libs.jackson.databind)
 }
-
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}

--- a/spi/registration-service-store-spi/build.gradle.kts
+++ b/spi/registration-service-store-spi/build.gradle.kts
@@ -13,11 +13,3 @@ dependencies {
     testFixturesImplementation(libs.assertj)
 
 }
-
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}

--- a/system-tests/build.gradle.kts
+++ b/system-tests/build.gradle.kts
@@ -32,3 +32,7 @@ dependencies {
     testImplementation(libs.mockserver.client)
     testImplementation(edc.core.junit)
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/launchers/participant/build.gradle.kts
+++ b/system-tests/launchers/participant/build.gradle.kts
@@ -42,3 +42,7 @@ tasks.withType<Tar> {
 tasks.withType<Zip> {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
+
+edcBuild {
+    publish.set(false)
+}


### PR DESCRIPTION
## What this PR changes/adds

Removes the Maven publications from the build files and sets the `publish` flag to false for modules that should not be published (launchers, system tests).

## Why it does that

Once [this PR](https://github.com/eclipse-edc/GradlePlugins/pull/67) is merged, Maven publications will be added automatically by the Plugin.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
