### PR TITLE
refactor: Use EdcHttpClient

### DIFF
--- a/core/registration-service-credential-service/src/main/java/org/eclipse/edc/registration/credential/DefaultOnboardedParticipantCredentialProvider.java
+++ b/core/registration-service-credential-service/src/main/java/org/eclipse/edc/registration/credential/DefaultOnboardedParticipantCredentialProvider.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.registration.credential;
 
 import org.eclipse.edc.identityhub.spi.credentials.model.Credential;
 import org.eclipse.edc.identityhub.spi.credentials.model.CredentialSubject;
+import org.eclipse.edc.identityhub.spi.credentials.model.VerifiableCredential;
 import org.eclipse.edc.registration.spi.credential.OnboardedParticipantCredentialProvider;
 import org.eclipse.edc.registration.spi.model.Participant;
 import org.eclipse.edc.spi.result.Result;
@@ -40,8 +41,8 @@ public class DefaultOnboardedParticipantCredentialProvider implements OnboardedP
     public Result<Credential> createCredential(Participant participant) {
         return Result.success(Credential.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .context("https://www.w3.org/2018/credentials/v1")
-                .type("VerifiableCredential")
+                .context(VerifiableCredential.DEFAULT_CONTEXT)
+                .type(VerifiableCredential.DEFAULT_TYPE)
                 .issuer(dataspaceDid)
                 .credentialSubject(CredentialSubject.Builder.newInstance()
                         .id(participant.getDid())

--- a/core/registration-service-credential-service/src/test/java/org/eclipse/edc/registration/credential/DefaultOnboardedParticipantCredentialProviderTest.java
+++ b/core/registration-service-credential-service/src/test/java/org/eclipse/edc/registration/credential/DefaultOnboardedParticipantCredentialProviderTest.java
@@ -14,9 +14,11 @@
 
 package org.eclipse.edc.registration.credential;
 
+import org.eclipse.edc.identityhub.spi.credentials.model.VerifiableCredential;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.registration.ParticipantUtils.createParticipant;
@@ -25,15 +27,15 @@ class DefaultOnboardedParticipantCredentialProviderTest {
 
     @Test
     void verifyCreateCredential() {
-        var dataspaceDid = "test";
+        var dataspaceDid = "did:web" + UUID.randomUUID();
         var provider = new DefaultOnboardedParticipantCredentialProvider(dataspaceDid);
         var participant = createParticipant().build();
 
         var result = provider.createCredential(participant);
         assertThat(result.succeeded()).isTrue();
         var credential = result.getContent();
-        assertThat(credential.getTypes()).containsExactly("VerifiableCredential");
-        assertThat(credential.getContexts()).containsExactly("https://www.w3.org/2018/credentials/v1");
+        assertThat(credential.getTypes()).containsExactly(VerifiableCredential.DEFAULT_TYPE);
+        assertThat(credential.getContexts()).containsExactly(VerifiableCredential.DEFAULT_CONTEXT);
         assertThat(credential.getIssuer()).isEqualTo(dataspaceDid);
         assertThat(credential.getCredentialSubject().getId()).isEqualTo(participant.getDid());
         assertThat(credential.getCredentialSubject().getClaims()).containsExactlyEntriesOf(Map.of("memberOfDataspace", dataspaceDid));

--- a/system-tests/src/test/java/org/eclipse/edc/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/edc/registration/client/RegistrationApiClientTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.registration.client;
 
-import okhttp3.OkHttpClient;
 import org.assertj.core.api.ThrowingConsumer;
 import org.eclipse.edc.identityhub.client.IdentityHubClientImpl;
 import org.eclipse.edc.identityhub.credentials.jwt.JwtCredentialEnvelope;
@@ -24,9 +23,9 @@ import org.eclipse.edc.identityhub.spi.credentials.model.Credential;
 import org.eclipse.edc.identityhub.spi.credentials.model.CredentialEnvelope;
 import org.eclipse.edc.identityhub.spi.credentials.model.CredentialSubject;
 import org.eclipse.edc.identityhub.spi.credentials.transformer.CredentialEnvelopeTransformerRegistryImpl;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.registration.cli.CryptoUtils;
 import org.eclipse.edc.registration.client.api.RegistryApi;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,11 +47,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
-import static org.eclipse.edc.registration.client.RegistrationServiceTestUtils.MAPPER;
 import static org.eclipse.edc.registration.client.RegistrationServiceTestUtils.createApi;
 import static org.eclipse.edc.registration.client.RegistrationServiceTestUtils.createDid;
 import static org.eclipse.edc.registration.client.RegistrationServiceTestUtils.didDocument;
-import static org.mockito.Mockito.mock;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -63,21 +60,21 @@ class RegistrationApiClientTest {
 
     private static final String HUB_BASE_URL = "http://localhost:8181/api/identity-hub";
     private static final String API_URL = "http://localhost:8182/authority";
-    private static final Monitor MONITOR = mock(Monitor.class);
+    private static final TypeManager TYPE_MANAGER = new TypeManager();
 
     private static IdentityHubClientImpl identityHubClient;
 
     private ClientAndServer httpSourceClientAndServer;
     private String did;
     private RegistryApi api;
+    private JwtCredentialFactory jwtCredentialFactory;
 
     @BeforeAll
     static void setUpClass() {
-        var mapper = new TypeManager().getMapper();
-        var okHttpClient = new OkHttpClient.Builder().build();
+        var okHttpClient = TestUtils.testHttpClient();
         var transformerRegistry = new CredentialEnvelopeTransformerRegistryImpl();
-        transformerRegistry.register(new JwtCredentialEnvelopeTransformer(mapper));
-        identityHubClient = new IdentityHubClientImpl(okHttpClient, mapper, MONITOR, transformerRegistry);
+        transformerRegistry.register(new JwtCredentialEnvelopeTransformer(TYPE_MANAGER.getMapper()));
+        identityHubClient = new IdentityHubClientImpl(okHttpClient, TYPE_MANAGER, transformerRegistry);
     }
 
     @BeforeEach
@@ -90,6 +87,7 @@ class RegistrationApiClientTest {
                         .withStatusCode(HttpStatusCode.OK_200.code()));
         did = createDid(apiPort);
         api = createApi(did, API_URL);
+        jwtCredentialFactory = new JwtCredentialFactory(TYPE_MANAGER.getMapper());
     }
 
     @AfterEach
@@ -130,7 +128,7 @@ class RegistrationApiClientTest {
         // sanity check
         assertThat(getVerifiableCredentialsFromIdentityHub()).noneSatisfy(vcRequirement(did, startTime));
 
-        var jwt = JwtCredentialFactory.buildSignedJwt(credential, issuer, did, authorityPrivateKey, MAPPER);
+        var jwt = jwtCredentialFactory.buildSignedJwt(credential, authorityPrivateKey);
         identityHubClient.addVerifiableCredential(HUB_BASE_URL, new JwtCredentialEnvelope(jwt));
 
         api.addParticipant();

--- a/system-tests/src/test/java/org/eclipse/edc/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/edc/registration/client/RegistrationApiCommandLineClientTest.java
@@ -45,22 +45,20 @@ import static org.mockserver.stop.Stop.stopQuietly;
 @IntegrationTest
 class RegistrationApiCommandLineClientTest {
 
-    static final ObjectMapper MAPPER = new ObjectMapper();
-    static Path privateKeyFile;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static Path privateKeyFile;
 
-    int apiPort;
-    String did;
-    /*
-    host.docker.internal is used in docker-compose file to connect from Registration Service container to a mock-service on the host
-     */
-    ClientAndServer httpSourceClientAndServer;
+    private String did;
+
+    // host.docker.internal is used in docker-compose file to connect from Registration Service container to a mock-service on the host
+    private ClientAndServer httpSourceClientAndServer;
 
     @BeforeEach
     void setUpClass() throws Exception {
         privateKeyFile = Files.createTempFile("test", ".pem");
         privateKeyFile.toFile().deleteOnExit();
         Files.writeString(privateKeyFile, TestKeyData.PRIVATE_KEY_P256);
-        apiPort = getFreePort();
+        var apiPort = getFreePort();
         httpSourceClientAndServer = startClientAndServer(apiPort);
         httpSourceClientAndServer.when(request().withPath("/.well-known/did.json"))
                 .respond(response()


### PR DESCRIPTION
## What this PR changes/adds

Use `EdcHttpClient` instead of `OkHttpClient`.

## Why it does that

`EdcHttpClient` embeds failsafe.

## Linked Issue(s)

Closes #65 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
