### PR TITLE
fix(CosmosParticipantStore): adds upsert manual semantic

### DIFF
--- a/extensions/store/cosmos/participant-store-cosmos/src/main/java/org/eclipse/edc/registration/store/cosmos/CosmosParticipantStore.java
+++ b/extensions/store/cosmos/participant-store-cosmos/src/main/java/org/eclipse/edc/registration/store/cosmos/CosmosParticipantStore.java
@@ -79,7 +79,11 @@ public class CosmosParticipantStore implements ParticipantStore {
     @Override
     public void save(Participant participant) {
         var document = new ParticipantDocument(participant, partitionKey);
-        participantDb.saveItem(document);
+        if (findByDid(participant.getDid()) == null) {
+            participantDb.createItem(document);
+        } else {
+            participantDb.updateItem(document);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Fix the compilation issue in `CosmosParticipantStore`

## Why it does that

It does not compile


## Linked Issue(s)

Closes #78  

Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
