### PR TITLE
fix: compilation and dependency cleanup

### DIFF
--- a/core/registration-service-client/build.gradle.kts
+++ b/core/registration-service-client/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     implementation(libs.edc.util)
     implementation(libs.edc.spi.http)
     implementation(libs.edc.core.connector)
-    implementation(libs.jackson.databind)
     implementation(libs.openapi.jackson.databind.nullable)
 
     testImplementation(libs.okhttp.mockwebserver)

--- a/core/registration-service-client/src/main/java/org/eclipse/edc/registration/client/response/ApiResult.java
+++ b/core/registration-service-client/src/main/java/org/eclipse/edc/registration/client/response/ApiResult.java
@@ -15,9 +15,10 @@
 package org.eclipse.edc.registration.client.response;
 
 import org.eclipse.edc.spi.result.AbstractResult;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.function.Function;
 
 
 public class ApiResult<T> extends AbstractResult<T, ApiFailure, ApiResult<T>> {
@@ -54,12 +55,10 @@ public class ApiResult<T> extends AbstractResult<T, ApiFailure, ApiResult<T>> {
         return new ApiResult<>(null, new ApiFailure(List.of(message), code));
     }
 
-    public <R> ApiResult<R> map(Function<T, R> mapFunction) {
-        if (succeeded()) {
-            return ApiResult.success(mapFunction.apply(getContent()));
-        } else {
-            return ApiResult.failure(reason(), getFailureDetail());
-        }
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <R1 extends AbstractResult<C1, ApiFailure, R1>, C1> @NotNull R1 newInstance(@Nullable C1 content, @Nullable ApiFailure failure) {
+        return (R1) new ApiResult<>(content, failure);
     }
 
     public int reason() {

--- a/core/registration-service-credential-service/build.gradle.kts
+++ b/core/registration-service-credential-service/build.gradle.kts
@@ -15,11 +15,3 @@ dependencies {
     testImplementation(testFixtures(project(":core:registration-service-client")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
-

--- a/core/registration-service/build.gradle.kts
+++ b/core/registration-service/build.gradle.kts
@@ -12,18 +12,10 @@ dependencies {
     implementation(libs.ih.ext.verifier.jwt)
     implementation(libs.ih.ext.credentials.jwt)
 
-    implementation(libs.opentelemetry.annotations)
+    implementation(libs.opentelemetry.instrumentation.annotations)
 
     testImplementation(testFixtures(project(":spi:registration-service-spi")))
     testImplementation(testFixtures(project(":spi:registration-service-store-spi")))
     testImplementation(testFixtures(project(":core:registration-service-client")))
-}
-
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
 }
 

--- a/core/registration-service/src/main/java/org/eclipse/edc/registration/manager/ParticipantManager.java
+++ b/core/registration-service/src/main/java/org/eclipse/edc/registration/manager/ParticipantManager.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.registration.manager;
 
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.registration.spi.model.Participant;
 import org.eclipse.edc.registration.spi.model.ParticipantStatus;
 import org.eclipse.edc.registration.spi.service.VerifiableCredentialService;

--- a/extensions/registration-service-api/build.gradle.kts
+++ b/extensions/registration-service-api/build.gradle.kts
@@ -10,17 +10,12 @@ dependencies {
     implementation(libs.edc.ext.http)
     implementation(libs.edc.ext.identity.did.crypto)
 
-    implementation(libs.opentelemetry.annotations)
-
     testImplementation(testFixtures(project(":spi:registration-service-spi")))
     testImplementation(testFixtures(project(":core:registration-service-client")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
+edcBuild {
+    swagger {
+        apiGroup.set("management-api")
     }
 }
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,14 +7,11 @@ awaitility = "4.2.0"
 edc = "0.0.1-SNAPSHOT"
 failsafe = "3.3.1"
 httpMockServer = "5.15.0"
-jackson = "2.14.2"
 jetbrains-annotations = "24.0.1"
 jupiter = "5.9.2"
 okhttp = "4.10.0"
 openApiTools = "0.2.1"
-openTelemetry = "1.18.0"
 picocli = "4.6.3"
-swaggerAnnotation = "1.5.22"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
@@ -58,7 +55,6 @@ edc-ext-vault-azure = { module = "org.eclipse.edc:vault-azure", version.ref = "e
 edc-ext-azure-cosmos-core = { module = "org.eclipse.edc:azure-cosmos-core", version.ref = "edc" }
 edc-ext-azure-test = { module = "org.eclipse.edc:azure-test", version.ref = "edc" }
 edc-ext-jdklogger = { module = "org.eclipse.edc:monitor-jdk-logger", version.ref = "edc" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiter" }
@@ -68,10 +64,10 @@ mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = 
 mockserver-client = { module = "org.mock-server:mockserver-client-java", version.ref = "httpMockServer" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp"}
 openapi-jackson-databind-nullable = { module = "org.openapitools:jackson-databind-nullable", version.ref = "openApiTools" }
-opentelemetry-annotations = { module = "io.opentelemetry:opentelemetry-extension-annotations", version.ref = "openTelemetry" }
-swagger-annotations = { module = "io.swagger:swagger-annotations", version.ref = "swaggerAnnotation" }
+opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version = "1.24.0" }
 
 [bundles]
 
 [plugins]
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.0.0" }
+swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin" }

--- a/registration-service-cli/build.gradle.kts
+++ b/registration-service-cli/build.gradle.kts
@@ -5,11 +5,9 @@ plugins {
 }
 
 dependencies {
+    api(project(":core:registration-service-client"))
     api(libs.picocli.core)
     annotationProcessor(libs.picocli.codegen)
-
-    api(project(":core:registration-service-client"))
-    implementation(libs.jackson.databind)
 
     implementation(libs.edc.ext.identity.did.web)
     implementation(libs.edc.ext.identity.did.crypto)

--- a/spi/registration-service-spi/build.gradle.kts
+++ b/spi/registration-service-spi/build.gradle.kts
@@ -8,5 +8,4 @@ dependencies {
     api(libs.edc.spi.policy.engine)
     api(libs.edc.spi.aggregate.service)
     api(libs.ih.spi.core)
-    implementation(libs.jackson.databind)
 }

--- a/spi/registration-service-store-spi/build.gradle.kts
+++ b/spi/registration-service-store-spi/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
 dependencies {
     api(project(":spi:registration-service-spi"))
 
-    implementation(libs.jackson.databind)
-
     testFixturesImplementation(libs.junit.jupiter.api)
     testFixturesImplementation(libs.junit.jupiter.params)
     testFixturesImplementation(libs.assertj)

--- a/system-tests/build.gradle.kts
+++ b/system-tests/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     testImplementation(libs.edc.spi.identity.did)
     testRuntimeOnly(project(":launcher"))
     testImplementation(libs.awaitility)
-    testImplementation(libs.jackson.databind)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)
     testImplementation(libs.edc.core.junit)


### PR DESCRIPTION
## What this PR changes/adds

Fixes compilation error on `ApiResult`

## Why it does that

ci

## Further notes

- removed some unused dependencies, avoid some deprecated calls, cleaned up build files a little.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
