### PR TITLE
fix(build): remove unused launcher dependency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,7 @@ _Briefly state why the change was necessary._
 
 ## Further notes
 
-_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
-signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
+_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
 
 ## Linked Issue(s)
 
@@ -22,5 +21,5 @@ Closes # <-- _insert Issue number if one exists_
 - [ ] added/updated copyright headers?
 - [ ] documented public classes/methods?
 - [ ] added/updated relevant documentation?
-- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
-- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
+- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
+- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -52,13 +52,15 @@ jobs:
       - name: 'Build package'
         run: ./gradlew -DuseFsVault="true" build
 
-      - name: 'Upgrade docker-compose (for --wait option)'
+      - name: 'Install docker compose plugin'
         run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/v2.17.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
+          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+          mkdir -p $DOCKER_CONFIG/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.17.2/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
 
-      - name: 'Run application in docker-compose'
-        run: docker-compose -f system-tests/docker-compose.yml up --build --wait
+      - name: 'Run application in docker compose'
+        run: docker compose -f system-tests/docker-compose.yml up --build --wait
         timeout-minutes: 10
 
       - name: 'Unit and system tests'
@@ -71,7 +73,7 @@ jobs:
           JACOCO: "true"
 
       - name: 'docker-compose logs'
-        run: docker-compose -f system-tests/docker-compose.yml logs
+        run: docker compose -f system-tests/docker-compose.yml logs
         if: always()
 
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: 'Upgrade docker-compose (for --wait option)'
         run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+          sudo curl -L https://github.com/docker/compose/releases/download/v2.17.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
 
       - name: 'Run application in docker-compose'
@@ -69,12 +69,6 @@ jobs:
         env:
           INTEGRATION_TEST: true
           JACOCO: "true"
-
-      #      - name: 'Publish Test Results'
-      #        uses: EnricoMi/publish-unit-test-result-action@v1
-      #        if: always()
-      #        with:
-      #          files: "**/test-results/**/*.xml"
 
       - name: 'docker-compose logs'
         run: docker-compose -f system-tests/docker-compose.yml logs

--- a/docs/developer/decision-records/2022-06-29-http-ports/README.md
+++ b/docs/developer/decision-records/2022-06-29-http-ports/README.md
@@ -22,6 +22,6 @@ This makes the List Participants endpoint available at `http://localhost:8182/au
 
 DID-based JWS authentication will be used for the Registration Service controller, using a JAX-RS filter.
 
-However, for docker health check (used in `docker-compose up --wait` in CI to wait until containers have successfully started), we use `curl` to access the health endpoint, which is deployed in the EDC default context. Therefore, we do not want to apply our authentication filter to the `default` context, and need to introduce an additional context for the API controller.
+However, for docker health check (used in `docker compose up --wait` in CI to wait until containers have successfully started), we use `curl` to access the health endpoint, which is deployed in the EDC default context. Therefore, we do not want to apply our authentication filter to the `default` context, and need to introduce an additional context for the API controller.
 
 It is also good practice not to expose health and management endpoints to public access. Deploying them on a different ports allow deployments to expose their port on internal routes only.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,6 @@ edc-spi-transaction-datasource = { module = "org.eclipse.edc:transaction-datasou
 edc-spi-identity-did = { module = "org.eclipse.edc:identity-did-spi", version.ref = "edc" }
 edc-spi-aggregate-service = { module = "org.eclipse.edc:aggregate-service-spi", version.ref = "edc" }
 edc-core-connector = { module = "org.eclipse.edc:connector-core", version.ref = "edc" }
-edc-core-controlPlane = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }
 edc-core-micrometer = { module = "org.eclipse.edc:micrometer-core", version.ref = "edc" }
 edc-core-api = { module = "org.eclipse.edc:api-core", version.ref = "edc" }
 edc-core-stateMachine = { module = "org.eclipse.edc:state-machine", version.ref = "edc" }

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     runtimeOnly(libs.edc.ext.identity.did.core)
     runtimeOnly(libs.edc.core.connector)
     runtimeOnly(libs.edc.boot)
-    runtimeOnly(libs.edc.core.controlPlane)
     runtimeOnly(libs.edc.ext.observability)
     runtimeOnly(libs.edc.core.micrometer)
     runtimeOnly(libs.edc.ext.micrometer.jetty)

--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -13,7 +13,7 @@ Build the application launchers:
 Run the application using Docker compose:
 
 ```bash
-docker-compose -f system-tests/docker-compose.yml up --build
+docker compose -f system-tests/docker-compose.yml up --build
 ```
 
 Run tests:


### PR DESCRIPTION
## What this PR changes/adds

Remove control-plane dependency from the `launcher`

## Why it does that

A registration service shouldn't declare the `control-plane` dependencies.

## Further notes

- updated docker-compose
- sync'd pull request template

## Linked Issue(s)

Closes #88 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
