### PR TITLE
build: add action to bump the snapshot version

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -1,0 +1,42 @@
+name: "Bump version in gradle.properties"
+description: "Increments the patch version of the version found in gradle.properties, appends -SNAPSHOT"
+inputs:
+  target_branch:
+    default: 'main'
+    description: "Branch on which the version bump is to be done."
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - name: read version from gradle.properties
+      shell: bash
+      run: |
+        # Prepare git env
+        git config user.name "eclipse-edc-bot"
+        git config user.email "edc-bot@eclipse.org"
+
+        # checkout target
+        git fetch origin
+        git checkout ${{ inputs.target_branch }}
+
+        # determine current version
+        oldVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}')
+
+        # read the major, minor, and patch components, consume -SNAPSHOT
+        IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"$oldVersion"
+
+        # construct the new version
+        newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))"-SNAPSHOT
+
+        # replace every occurrence of =$oldVersion with =$newVersion
+        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i 's/$oldVersion/$newVersion/g'
+
+        echo "Bumped the version from $oldVersion to $newVersion"
+
+        # Commit and push to the desired branch, defaults to 'main'
+        git add .
+        git commit --message "Bump version from $oldVersion to $newVersion [skip ci]"
+
+        git push origin ${{ inputs.target_branch }}

--- a/.github/workflows/release-registrationservice.yml
+++ b/.github/workflows/release-registrationservice.yml
@@ -39,11 +39,11 @@ jobs:
           commit_message_template: 'Merge commit for release of version v${{ env.REGISTRATION_SERVICE_VERSION }}'
 
     outputs:
-      ih-version: ${{ env.REGISTRATION_SERVICE_VERSION }}
+      rs-version: ${{ env.REGISTRATION_SERVICE_VERSION }}
 
   Github-Release:
     # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
-    if: ${{ !endsWith( needs.Prepare-Release.outputs.ih-version, '-SNAPSHOT') }}
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.rs-version, '-SNAPSHOT') }}
     needs:
       - Prepare-Release
     runs-on: ubuntu-latest
@@ -60,3 +60,15 @@ jobs:
           tag: "v${{ env.REGISTRATION_SERVICE_VERSION }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           removeArtifacts: true
+
+    Bump-Version:
+    name: 'Update release version'
+    # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.rs-version, '-SNAPSHOT') }}
+    needs: [ Prepare-Release, Github-Release ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bump-version
+        with:
+          target_branch: "main"


### PR DESCRIPTION
## What this PR changes/adds

Adds a job to automatically bump the version after a GH release

## Why it does that

updated the version automatically

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

