### PR TITLE
chore: update snapshot version to 0.1.0-SNAPSHOT

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -31,7 +31,7 @@ runs:
         newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))"-SNAPSHOT
 
         # replace every occurrence of =$oldVersion with =$newVersion
-        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i 's/$oldVersion/$newVersion/g'
+        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i "s/$oldVersion/$newVersion/g"
 
         echo "Bumped the version from $oldVersion to $newVersion"
 

--- a/core/registration-service-credential-service/src/main/java/org/eclipse/edc/registration/VerifiableCredentialServiceExtension.java
+++ b/core/registration-service-credential-service/src/main/java/org/eclipse/edc/registration/VerifiableCredentialServiceExtension.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.PrivateKeyResolver;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 
 import java.util.Objects;
 
@@ -59,6 +60,9 @@ public class VerifiableCredentialServiceExtension implements ServiceExtension {
     @Inject
     private OnboardedParticipantCredentialProvider credentialProvider;
 
+    @Inject
+    private TypeManager typeManager;
+
     @Override
     public String name() {
         return NAME;
@@ -66,11 +70,11 @@ public class VerifiableCredentialServiceExtension implements ServiceExtension {
 
     @Provider
     public VerifiableCredentialService verifiableCredentialService(ServiceExtensionContext context) {
-        var mapper = context.getTypeManager().getMapper();
+        var mapper = typeManager.getMapper();
 
         var credentialEnvelopeTransformerRegistry = new CredentialEnvelopeTransformerRegistryImpl();
         credentialEnvelopeTransformerRegistry.register(new JwtCredentialEnvelopeTransformer(mapper));
-        var identityHubClient = new IdentityHubClientImpl(httpClient, context.getTypeManager(), credentialEnvelopeTransformerRegistry);
+        var identityHubClient = new IdentityHubClientImpl(httpClient, typeManager, credentialEnvelopeTransformerRegistry);
 
         var privateKeyWrapper = privateKeyResolver.resolvePrivateKey(context.getConnectorId(), PrivateKeyWrapper.class);
         Objects.requireNonNull(privateKeyWrapper, "Couldn't resolve private key from connector " + context.getConnectorId());

--- a/extensions/store/cosmos/participant-store-cosmos/src/main/java/org/eclipse/edc/registration/store/cosmos/CosmosParticipantStoreExtension.java
+++ b/extensions/store/cosmos/participant-store-cosmos/src/main/java/org/eclipse/edc/registration/store/cosmos/CosmosParticipantStoreExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
+import org.eclipse.edc.spi.types.TypeManager;
 
 /**
  * Extension that provides a {@link ParticipantStore} with CosmosDB as backend storage
@@ -43,6 +44,9 @@ public class CosmosParticipantStoreExtension implements ServiceExtension {
     @Inject
     private CosmosClientProvider clientProvider;
 
+    @Inject
+    private TypeManager typeManager;
+
     private CosmosDbApi cosmosDbApi;
 
     @Override
@@ -53,7 +57,7 @@ public class CosmosParticipantStoreExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         context.getService(HealthCheckService.class).addReadinessProvider(() -> cosmosDbApi.get().forComponent(name()));
-        context.getTypeManager().registerTypes(ParticipantDocument.class);
+        typeManager.registerTypes(ParticipantDocument.class);
     }
 
     @Provider
@@ -61,6 +65,6 @@ public class CosmosParticipantStoreExtension implements ServiceExtension {
         var configuration = new ParticipantStoreCosmosConfig(context);
         var client = clientProvider.createClient(vault, configuration);
         cosmosDbApi = new CosmosDbApiImpl(configuration, client);
-        return new CosmosParticipantStore(cosmosDbApi, configuration.getPartitionKey(), context.getTypeManager().getMapper(), retryPolicy);
+        return new CosmosParticipantStore(cosmosDbApi, configuration.getPartitionKey(), typeManager.getMapper(), retryPolicy);
     }
 }

--- a/extensions/store/sql/participant-store-sql/src/main/java/org/eclipse/edc/registration/store/sql/SqlParticipantStoreExtension.java
+++ b/extensions/store/sql/participant-store-sql/src/main/java/org/eclipse/edc/registration/store/sql/SqlParticipantStoreExtension.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -46,6 +47,9 @@ public class SqlParticipantStoreExtension implements ServiceExtension {
     @Inject
     private TransactionContext trxContext;
 
+    @Inject
+    private TypeManager typeManager;
+
     @Override
     public String name() {
         return NAME;
@@ -54,7 +58,7 @@ public class SqlParticipantStoreExtension implements ServiceExtension {
 
     @Provider
     public ParticipantStore participantStore(ServiceExtensionContext context) {
-        return new SqlParticipantStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl());
+        return new SqlParticipantStore(dataSourceRegistry, getDataSourceName(context), trxContext, typeManager.getMapper(), getStatementImpl());
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 group=org.eclipse.edc
-version=0.0.1-SNAPSHOT
+version=0.1.0-SNAPSHOT
 
-edcGradlePluginsVersion=0.0.1-SNAPSHOT
-annotationProcessorVersion=0.0.1-SNAPSHOT
-metaModelVersion=0.0.1-SNAPSHOT
+edcGradlePluginsVersion=0.1.0-SNAPSHOT
+annotationProcessorVersion=0.1.0-SNAPSHOT
+metaModelVersion=0.1.0-SNAPSHOT
 
 # information required for publishing artifacts:
 edcScmConnection=scm:git:git@github.com:eclipse-edc/RegistrationService.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ format.version = "1.1"
 [versions]
 assertj = "3.23.1"
 awaitility = "4.2.0"
-edc = "0.0.1-SNAPSHOT"
+edc = "0.1.0-SNAPSHOT"
 failsafe = "3.3.1"
 httpMockServer = "5.15.0"
 jetbrains-annotations = "24.0.1"


### PR DESCRIPTION
## What this PR changes/adds

Update snapshot version to `0.1.0-SNAPSHOT`

## Why it does that

Our next release version will be `0.1.0`, thus the next snapshot will be `0.1.1-SNAPSHOT` and the automatic version bump mechanism currently only bumps the `patch` version.

## Further notes

- depends on https://github.com/eclipse-edc/GradlePlugins/pull/162
- depends on https://github.com/eclipse-edc/Connector/pull/3108


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
