### PR TITLE
fix: compile errors, pin EDC version

### DIFF
--- a/extensions/registration-service-api/src/main/java/org/eclipse/edc/registration/auth/DidJwtAuthenticationFilter.java
+++ b/extensions/registration-service-api/src/main/java/org/eclipse/edc/registration/auth/DidJwtAuthenticationFilter.java
@@ -97,7 +97,7 @@ public class DidJwtAuthenticationFilter implements ContainerRequestFilter {
     }
 
     private void verifyTokenSignature(SignedJWT jwt, String issuer, String kid) {
-        var publicKey = didPublicKeyResolver.resolvePublicKey(issuer, kid);
+        var publicKey = didPublicKeyResolver.resolvePublicKey(issuer + "#" + kid);
 
         if (publicKey.failed()) {
             throw authenticationFailure("Failed obtaining public key for DID: " + issuer, publicKey.getFailureMessages());

--- a/extensions/registration-service-api/src/test/java/org/eclipse/edc/registration/auth/DidJwtAuthenticationFilterTest.java
+++ b/extensions/registration-service-api/src/test/java/org/eclipse/edc/registration/auth/DidJwtAuthenticationFilterTest.java
@@ -36,8 +36,7 @@ import java.time.Clock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.eclipse.edc.registration.auth.DidJwtAuthenticationFilter.CALLER_DID_HEADER;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +60,7 @@ class DidJwtAuthenticationFilterTest {
         when(request.getHeaders()).thenReturn(headers);
         privateKey = new EcPrivateKeyWrapper(JWK.parseFromPEMEncodedObjects(TestKeyData.PRIVATE_KEY_P256).toECKey());
         var publicKey = new EcPublicKeyWrapper(JWK.parseFromPEMEncodedObjects(TestKeyData.PUBLIC_KEY_P256).toECKey());
-        when(didPublicKeyResolver.resolvePublicKey(eq(issuer), any()))
+        when(didPublicKeyResolver.resolvePublicKey(startsWith(issuer)))
                 .thenReturn(Result.success(publicKey));
 
         authHeader = "Bearer " + getTokenFor(audience);
@@ -104,7 +103,7 @@ class DidJwtAuthenticationFilterTest {
     @Test
     void filter_onUnresolvedDid_fails() {
         headers.putSingle(AUTHORIZATION, authHeader);
-        when(didPublicKeyResolver.resolvePublicKey(eq(issuer), any()))
+        when(didPublicKeyResolver.resolvePublicKey(startsWith(issuer)))
                 .thenReturn(Result.failure("Test Failure"));
 
         assertNotAuthenticated("Failed obtaining public key for DID: " + issuer);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ format.version = "1.1"
 [versions]
 assertj = "3.24.2"
 awaitility = "4.2.0"
-edc = "0.4.2-SNAPSHOT"
+edc = "0.4.1"
 # we need to pin the version of IH, because this is the last version to contain the DWN implementation
 # current snapshot builds of IH don't have feature parity yet.
 # todo: remove this once IH supports credential presentation and issuance

--- a/system-tests/src/test/java/org/eclipse/edc/registration/client/RegistrationServiceTestUtils.java
+++ b/system-tests/src/test/java/org/eclipse/edc/registration/client/RegistrationServiceTestUtils.java
@@ -47,7 +47,7 @@ class RegistrationServiceTestUtils {
 
     static String didDocument() throws Exception {
         var publicKey = (ECKey) ECKey.parseFromPEMEncodedObjects(TestKeyData.PUBLIC_KEY_P256);
-        var vm = VerificationMethod.Builder.newInstance()
+        var vm = VerificationMethod.Builder.create()
                 .id("#my-key-1")
                 .type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019)
                 .controller("")


### PR DESCRIPTION
## What this PR changes/adds

Pins the EDC version to 0.4.1 and fixes some compile errors

## Why it does that

EDC has progressed on and done some extensive refactoring, none of which RS is compatible with unless it undergoes 
an equally extensive refactoring.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
